### PR TITLE
No storage devices found on some computers

### DIFF
--- a/board/shredos/grub.cfg
+++ b/board/shredos/grub.cfg
@@ -2,5 +2,5 @@ set default="0"
 set timeout="0"
 
 menuentry "shredos" {
-	linux /boot/shredos console=tty3 loglevel=3 acpi=off
+	linux /boot/shredos console=tty3 loglevel=3
 }


### PR DESCRIPTION
Remove acpi=off as this was causing an issue of drives not being recognised on some computers, resulting a repeating error message: storage devices not found. Reenabling acpi in grub.cfg fixed this issue.

Closes #2 