### PR TITLE
Add post-wipe and pre-wipe scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ A certificate can optionally be created for each drive erased, the default is to
 1. [Saving nwipes PDF certificates and log files to USB ftp or tftp servers](#saving-nwipes-pdf-certificates-and-log-files-to-USB-ftp-or-tftp-servers)
    1. [Transferring nwipe log files to a USB storage device](#transferring-nwipe-log-files-to-a-usb-storage-device)
    1. [Transferring nwipe log files to a ftp server using lftp](#transferring-nwipe-log-files-to-a-ftp-server-using-lftp)
+1. [Fetch and run custom scripts before and after wiping](#fetch-and-run-custom-scripts-before-and-after-wiping)
 1. [How to wipe drives on headless systems or systems with faulty display hardware. (For use on secure LANs only)](#how-to-wipe-drives-on-headless-systems-or-systems-with-faulty-display-hardware-for-use-on-secure-lans-only)
 1. [Nwipe's font size is too small, How to double the size of the text](#nwipes-font-size-is-too-small-how-to-double-the-size-of-the-text)
 1. [Included Packages](#Included-Packages)
@@ -509,6 +510,34 @@ chroot_list_enable=NO
 secure_chroot_dir=/home/yournewftpuser/ftpdata
 ```
 Disclaimer: The above settings should get you going but may or may not be ideal for your local situation. Refer to the vsftp website and forums if things aren't working as they should. The lftp application that ShredOS uses, should also work with any Microsoft Windows based ftp server, as well as Linux and MAC based systems.
+
+## Fetch and run custom scripts before and after wiping
+
+ShredOS can automatically download and execute custom shell scripts immediately before and after each wipe cycle — without rebuilding the image. This is useful for workflows that need to register or decommission an asset on an external system, perform pre-wipe checks, or send a notification once wiping is complete. Both scripts are fetched over HTTP at boot time, so no changes to the ShredOS USB drive are required.
+
+Add either or both of the following options to the kernel command line in `/boot/grub/grub.cfg` and `/EFI/BOOT/grub.cfg`. The value is a URL, optionally followed by arguments that will be passed to the script when it runs.
+
+**`shredos_pre_wipe="<url> [arguments]"`**
+
+The script at `<url>` is downloaded and executed *before* nwipe starts. If the download fails, nwipe will not start and the failure will be logged to `transfer.log`. A non-zero exit code from the script is logged but does not prevent the wipe from proceeding.
+
+**`shredos_post_wipe="<url> [arguments]"`**
+
+The script at `<url>` is downloaded and executed *after* nwipe exits and after log files and PDF certificates have been transferred to the USB drive or network server. If the download fails, nwipe will not start and the failure will be logged to `transfer.log`. A non-zero exit code from the script is logged but does not prevent shutdown or reboot.
+
+**IMPORTANT**
+- Both scripts are downloaded fresh at the start of each wipe cycle, so you can update them on your server at any time without touching the ShredOS USB drive.
+- If a script URL is configured but cannot be downloaded, nwipe will be aborted.
+
+Example `grub.cfg` with both scripts configured:
+```
+set default="0"
+set timeout="0"
+
+menuentry "shredos" {
+	linux /boot/shredos console=tty3 loglevel=3 shredos_pre_wipe="http://192.168.0.2/scripts/pre_wipe.sh --site WAREHOUSE1" shredos_post_wipe="http://192.168.0.2/scripts/post_wipe.sh --notify slack"
+}
+```
 
 ## How to wipe drives on headless systems or systems with faulty display hardware. (For use on secure LANs only)
 ShredOS includes a user enabled telnet server. The downloadable .img images are supplied with telnet disabled as default.

--- a/board/shredos/fsoverlay/usr/bin/nwipe_launcher
+++ b/board/shredos/fsoverlay/usr/bin/nwipe_launcher
@@ -120,7 +120,7 @@ fi
 
 # Has shredos_exclude_boot_disc="yes" been placed on the kernel command line?
 exclude_boot_disc_cmd=""
-exclude_boot_disc_status=$(kernel_cmdline_extractor shredos_exclude_boot_disc)
+exclude_boot_disc_status=$( shredos_exclude_boot_disc)
 if [ $? == 0 ]
 then
 	if [[ "${exclude_boot_disc_status,,}" == "yes" ]]
@@ -441,11 +441,80 @@ sleep 2
 #
 while true
 do
-	if [ $nwipe_options_flag == 0 ]
+	# Download pre-wipe and callback scripts before nwipe starts.
+	# If either configured script cannot be downloaded, nwipe will not start.
+	# example: shredos_nwipe_pre_wipe="http://192.168.0.2/scripts/pre_wipe.sh --arg1 val1 --arg2"
+	# example: shredos_nwipe_callback="http://192.168.0.2/scripts/post_wipe.sh --arg1 val1 --arg2"
+	#
+	scripts_ok=1
+	nwipe_pre_wipe_url=""
+	nwipe_pre_wipe_options=""
+	nwipe_callback_url=""
+	nwipe_callback_options=""
+
+	nwipe_pre_wipe_string=$(kernel_cmdline_extractor shredos_nwipe_pre_wipe)
+	if [ $? == 0 ]
 	then
-		/usr/bin/nwipe --logfile=$logfile $launcher_options $exclude_boot_disc_cmd
-	else
-		/usr/bin/nwipe --logfile=$logfile $launcher_options $nwipe_options_string $exclude_boot_disc_cmd
+		read nwipe_pre_wipe_url nwipe_pre_wipe_options <<< "$nwipe_pre_wipe_string"
+		printf "[`date "$date_format"`] Found shredos_nwipe_pre_wipe on kernel command line\n" 2>&1 | tee -a transfer.log
+		printf "[`date "$date_format"`] Pre-wipe URL = $nwipe_pre_wipe_url\n" 2>&1 | tee -a transfer.log
+		printf "[`date "$date_format"`] Pre-wipe options = $nwipe_pre_wipe_options\n" 2>&1 | tee -a transfer.log
+		printf "[`date "$date_format"`] Downloading pre-wipe script from $nwipe_pre_wipe_url\n" 2>&1 | tee -a wget.log
+		wget --no-check-certificate -O /tmp/nwipe_pre_wipe.sh "$nwipe_pre_wipe_url" -nv >> wget.log 2>&1
+		if [ $? == 0 ]
+		then
+			printf "[`date "$date_format"`] Pre-wipe script downloaded successfully\n" 2>&1 | tee -a transfer.log
+			chmod +x /tmp/nwipe_pre_wipe.sh
+		else
+			printf "[`date "$date_format"`] [FAILED] Could not download pre-wipe script from $nwipe_pre_wipe_url\n" 2>&1 | tee -a transfer.log
+			scripts_ok=0
+		fi
+	fi
+
+	nwipe_callback_string=$(kernel_cmdline_extractor shredos_nwipe_callback)
+	if [ $? == 0 ]
+	then
+		read nwipe_callback_url nwipe_callback_options <<< "$nwipe_callback_string"
+		printf "[`date "$date_format"`] Found shredos_nwipe_callback on kernel command line\n" 2>&1 | tee -a transfer.log
+		printf "[`date "$date_format"`] Callback URL = $nwipe_callback_url\n" 2>&1 | tee -a transfer.log
+		printf "[`date "$date_format"`] Callback options = $nwipe_callback_options\n" 2>&1 | tee -a transfer.log
+		printf "[`date "$date_format"`] Downloading callback script from $nwipe_callback_url\n" 2>&1 | tee -a wget.log
+		wget --no-check-certificate -O /tmp/nwipe_callback.sh "$nwipe_callback_url" -nv >> wget.log 2>&1
+		if [ $? == 0 ]
+		then
+			printf "[`date "$date_format"`] Callback script downloaded successfully\n" 2>&1 | tee -a transfer.log
+			chmod +x /tmp/nwipe_callback.sh
+		else
+			printf "[`date "$date_format"`] [FAILED] Could not download callback script from $nwipe_callback_url\n" 2>&1 | tee -a transfer.log
+			scripts_ok=0
+		fi
+	fi
+
+	if [ $scripts_ok == 0 ]
+	then
+		printf "[`date "$date_format"`] [ABORTED] One or more scripts failed to download. nwipe will not start.\n" 2>&1 | tee -a transfer.log
+	fi
+
+	if [ $scripts_ok == 1 ]
+	then
+		if [ "$nwipe_pre_wipe_url" != "" ]
+		then
+			printf "[`date "$date_format"`] Executing pre-wipe script\n" 2>&1 | tee -a transfer.log
+			/tmp/nwipe_pre_wipe.sh $nwipe_pre_wipe_options
+			if [ $? == 0 ]
+			then
+				printf "[`date "$date_format"`] Pre-wipe script completed successfully\n" 2>&1 | tee -a transfer.log
+			else
+				printf "[`date "$date_format"`] Pre-wipe script exited with an error\n" 2>&1 | tee -a transfer.log
+			fi
+		fi
+
+		if [ $nwipe_options_flag == 0 ]
+		then
+			/usr/bin/nwipe --logfile=$logfile $launcher_options $exclude_boot_disc_cmd
+		else
+			/usr/bin/nwipe --logfile=$logfile $launcher_options $nwipe_options_string $exclude_boot_disc_cmd
+		fi
 	fi
 
 	# ----
@@ -757,33 +826,17 @@ do
 	fi
 		printf "______________________________________________________________________________\n" 2>&1  | tee -a transfer.log
 
-	# read the kernel command line for a callback URL (and optional arguments) to download
-	# and execute after the wipe and all transfers have completed.
-	# example: shredos_nwipe_callback="http://192.168.0.2/scripts/post_wipe.sh --arg1 val1 --arg2"
+	# Execute the callback script downloaded before nwipe started.
 	#
-	nwipe_callback_string=$(kernel_cmdline_extractor shredos_nwipe_callback)
-	if [ $? == 0 ]
+	if [ "$nwipe_callback_url" != "" ]
 	then
-		read nwipe_callback_url nwipe_callback_options <<< "$nwipe_callback_string"
-		printf "[`date "$date_format"`] Found shredos_nwipe_callback on kernel command line\n" 2>&1 | tee -a transfer.log
-		printf "[`date "$date_format"`] Callback URL = $nwipe_callback_url\n" 2>&1 | tee -a transfer.log
-		printf "[`date "$date_format"`] Callback options = $nwipe_callback_options\n" 2>&1 | tee -a transfer.log
-		printf "[`date "$date_format"`] Downloading callback script from $nwipe_callback_url\n" 2>&1 | tee -a wget.log
-		wget --no-check-certificate -O /tmp/nwipe_callback.sh "$nwipe_callback_url" -nv >> wget.log 2>&1
+		printf "[`date "$date_format"`] Executing callback script\n" 2>&1 | tee -a transfer.log
+		/tmp/nwipe_callback.sh $nwipe_callback_options
 		if [ $? == 0 ]
 		then
-			printf "[`date "$date_format"`] Callback script downloaded successfully\n" 2>&1 | tee -a transfer.log
-			chmod +x /tmp/nwipe_callback.sh
-			printf "[`date "$date_format"`] Executing callback script\n" 2>&1 | tee -a transfer.log
-			/tmp/nwipe_callback.sh $nwipe_callback_options
-			if [ $? == 0 ]
-			then
-				printf "[`date "$date_format"`] Callback script completed successfully\n" 2>&1 | tee -a transfer.log
-			else
-				printf "[`date "$date_format"`] Callback script exited with an error\n" 2>&1 | tee -a transfer.log
-			fi
+			printf "[`date "$date_format"`] Callback script completed successfully\n" 2>&1 | tee -a transfer.log
 		else
-			printf "[`date "$date_format"`] [FAILED] Could not download callback script from $nwipe_callback_url\n" 2>&1 | tee -a transfer.log
+			printf "[`date "$date_format"`] Callback script exited with an error\n" 2>&1 | tee -a transfer.log
 		fi
 	fi
 

--- a/board/shredos/fsoverlay/usr/bin/nwipe_launcher
+++ b/board/shredos/fsoverlay/usr/bin/nwipe_launcher
@@ -120,7 +120,7 @@ fi
 
 # Has shredos_exclude_boot_disc="yes" been placed on the kernel command line?
 exclude_boot_disc_cmd=""
-exclude_boot_disc_status=$( shredos_exclude_boot_disc)
+exclude_boot_disc_status=$(kernel_cmdline_extractor shredos_exclude_boot_disc)
 if [ $? == 0 ]
 then
 	if [[ "${exclude_boot_disc_status,,}" == "yes" ]]

--- a/board/shredos/fsoverlay/usr/bin/nwipe_launcher
+++ b/board/shredos/fsoverlay/usr/bin/nwipe_launcher
@@ -757,14 +757,17 @@ do
 	fi
 		printf "______________________________________________________________________________\n" 2>&1  | tee -a transfer.log
 
-	# read the kernel command line for a callback URL to download and execute after
-	# the wipe and all transfers have completed.
-	# example: shredos_nwipe_callback="http://192.168.0.2/scripts/post_wipe.sh"
+	# read the kernel command line for a callback URL (and optional arguments) to download
+	# and execute after the wipe and all transfers have completed.
+	# example: shredos_nwipe_callback="http://192.168.0.2/scripts/post_wipe.sh --arg1 val1 --arg2"
 	#
-	nwipe_callback_url=$(kernel_cmdline_extractor shredos_nwipe_callback)
+	nwipe_callback_string=$(kernel_cmdline_extractor shredos_nwipe_callback)
 	if [ $? == 0 ]
 	then
+		read nwipe_callback_url nwipe_callback_options <<< "$nwipe_callback_string"
 		printf "[`date "$date_format"`] Found shredos_nwipe_callback on kernel command line\n" 2>&1 | tee -a transfer.log
+		printf "[`date "$date_format"`] Callback URL = $nwipe_callback_url\n" 2>&1 | tee -a transfer.log
+		printf "[`date "$date_format"`] Callback options = $nwipe_callback_options\n" 2>&1 | tee -a transfer.log
 		printf "[`date "$date_format"`] Downloading callback script from $nwipe_callback_url\n" 2>&1 | tee -a wget.log
 		wget --no-check-certificate -O /tmp/nwipe_callback.sh "$nwipe_callback_url" -nv >> wget.log 2>&1
 		if [ $? == 0 ]
@@ -772,7 +775,7 @@ do
 			printf "[`date "$date_format"`] Callback script downloaded successfully\n" 2>&1 | tee -a transfer.log
 			chmod +x /tmp/nwipe_callback.sh
 			printf "[`date "$date_format"`] Executing callback script\n" 2>&1 | tee -a transfer.log
-			/tmp/nwipe_callback.sh
+			/tmp/nwipe_callback.sh $nwipe_callback_options
 			if [ $? == 0 ]
 			then
 				printf "[`date "$date_format"`] Callback script completed successfully\n" 2>&1 | tee -a transfer.log

--- a/board/shredos/fsoverlay/usr/bin/nwipe_launcher
+++ b/board/shredos/fsoverlay/usr/bin/nwipe_launcher
@@ -757,6 +757,33 @@ do
 	fi
 		printf "______________________________________________________________________________\n" 2>&1  | tee -a transfer.log
 
+	# read the kernel command line for a callback URL to download and execute after
+	# the wipe and all transfers have completed.
+	# example: shredos_nwipe_callback="http://192.168.0.2/scripts/post_wipe.sh"
+	#
+	nwipe_callback_url=$(kernel_cmdline_extractor shredos_nwipe_callback)
+	if [ $? == 0 ]
+	then
+		printf "[`date "$date_format"`] Found shredos_nwipe_callback on kernel command line\n" 2>&1 | tee -a transfer.log
+		printf "[`date "$date_format"`] Downloading callback script from $nwipe_callback_url\n" 2>&1 | tee -a wget.log
+		wget --no-check-certificate -O /tmp/nwipe_callback.sh "$nwipe_callback_url" -nv >> wget.log 2>&1
+		if [ $? == 0 ]
+		then
+			printf "[`date "$date_format"`] Callback script downloaded successfully\n" 2>&1 | tee -a transfer.log
+			chmod +x /tmp/nwipe_callback.sh
+			printf "[`date "$date_format"`] Executing callback script\n" 2>&1 | tee -a transfer.log
+			/tmp/nwipe_callback.sh
+			if [ $? == 0 ]
+			then
+				printf "[`date "$date_format"`] Callback script completed successfully\n" 2>&1 | tee -a transfer.log
+			else
+				printf "[`date "$date_format"`] Callback script exited with an error\n" 2>&1 | tee -a transfer.log
+			fi
+		else
+			printf "[`date "$date_format"`] [FAILED] Could not download callback script from $nwipe_callback_url\n" 2>&1 | tee -a transfer.log
+		fi
+	fi
+
 	# If the user has specified `shredos_autoreboot=enable` on the kernel command line
 	#
 	if [ "$autoreboot" == "enable" ]

--- a/board/shredos/fsoverlay/usr/bin/nwipe_launcher
+++ b/board/shredos/fsoverlay/usr/bin/nwipe_launcher
@@ -443,49 +443,49 @@ while true
 do
 	# Download pre-wipe and callback scripts before nwipe starts.
 	# If either configured script cannot be downloaded, nwipe will not start.
-	# example: shredos_nwipe_pre_wipe="http://192.168.0.2/scripts/pre_wipe.sh --arg1 val1 --arg2"
-	# example: shredos_nwipe_callback="http://192.168.0.2/scripts/post_wipe.sh --arg1 val1 --arg2"
+	# example: shredos_pre_wipe="http://192.168.0.2/scripts/pre_wipe.sh --arg1 val1 --arg2"
+	# example: shredos_post_wipe="http://192.168.0.2/scripts/post_wipe.sh --arg1 val1 --arg2"
 	#
 	scripts_ok=1
-	nwipe_pre_wipe_url=""
-	nwipe_pre_wipe_options=""
-	nwipe_callback_url=""
-	nwipe_callback_options=""
+	pre_wipe_url=""
+	pre_wipe_options=""
+	post_wipe_url=""
+	post_wipe_options=""
 
-	nwipe_pre_wipe_string=$(kernel_cmdline_extractor shredos_nwipe_pre_wipe)
+	pre_wipe_string=$(kernel_cmdline_extractor shredos_pre_wipe)
 	if [ $? == 0 ]
 	then
-		read nwipe_pre_wipe_url nwipe_pre_wipe_options <<< "$nwipe_pre_wipe_string"
-		printf "[`date "$date_format"`] Found shredos_nwipe_pre_wipe on kernel command line\n" 2>&1 | tee -a transfer.log
-		printf "[`date "$date_format"`] Pre-wipe URL = $nwipe_pre_wipe_url\n" 2>&1 | tee -a transfer.log
-		printf "[`date "$date_format"`] Pre-wipe options = $nwipe_pre_wipe_options\n" 2>&1 | tee -a transfer.log
-		printf "[`date "$date_format"`] Downloading pre-wipe script from $nwipe_pre_wipe_url\n" 2>&1 | tee -a wget.log
-		wget --no-check-certificate -O /tmp/nwipe_pre_wipe.sh "$nwipe_pre_wipe_url" -nv >> wget.log 2>&1
+		read pre_wipe_url pre_wipe_options <<< "$pre_wipe_string"
+		printf "[`date "$date_format"`] Found shredos_pre_wipe on kernel command line\n" 2>&1 | tee -a transfer.log
+		printf "[`date "$date_format"`] Pre-wipe URL = $pre_wipe_url\n" 2>&1 | tee -a transfer.log
+		printf "[`date "$date_format"`] Pre-wipe options = $pre_wipe_options\n" 2>&1 | tee -a transfer.log
+		printf "[`date "$date_format"`] Downloading pre-wipe script from $pre_wipe_url\n" 2>&1 | tee -a wget.log
+		wget --no-check-certificate -O /tmp/pre_wipe.sh "$pre_wipe_url" -nv >> wget.log 2>&1
 		if [ $? == 0 ]
 		then
 			printf "[`date "$date_format"`] Pre-wipe script downloaded successfully\n" 2>&1 | tee -a transfer.log
-			chmod +x /tmp/nwipe_pre_wipe.sh
+			chmod +x /tmp/pre_wipe.sh
 		else
-			printf "[`date "$date_format"`] [FAILED] Could not download pre-wipe script from $nwipe_pre_wipe_url\n" 2>&1 | tee -a transfer.log
+			printf "[`date "$date_format"`] [FAILED] Could not download pre-wipe script from $pre_wipe_url\n" 2>&1 | tee -a transfer.log
 			scripts_ok=0
 		fi
 	fi
 
-	nwipe_callback_string=$(kernel_cmdline_extractor shredos_nwipe_callback)
+	post_wipe_string=$(kernel_cmdline_extractor shredos_post_wipe)
 	if [ $? == 0 ]
 	then
-		read nwipe_callback_url nwipe_callback_options <<< "$nwipe_callback_string"
-		printf "[`date "$date_format"`] Found shredos_nwipe_callback on kernel command line\n" 2>&1 | tee -a transfer.log
-		printf "[`date "$date_format"`] Callback URL = $nwipe_callback_url\n" 2>&1 | tee -a transfer.log
-		printf "[`date "$date_format"`] Callback options = $nwipe_callback_options\n" 2>&1 | tee -a transfer.log
-		printf "[`date "$date_format"`] Downloading callback script from $nwipe_callback_url\n" 2>&1 | tee -a wget.log
-		wget --no-check-certificate -O /tmp/nwipe_callback.sh "$nwipe_callback_url" -nv >> wget.log 2>&1
+		read post_wipe_url post_wipe_options <<< "$post_wipe_string"
+		printf "[`date "$date_format"`] Found shredos_post_wipe on kernel command line\n" 2>&1 | tee -a transfer.log
+		printf "[`date "$date_format"`] Post-wipe URL = $post_wipe_url\n" 2>&1 | tee -a transfer.log
+		printf "[`date "$date_format"`] Post-wipe options = $post_wipe_options\n" 2>&1 | tee -a transfer.log
+		printf "[`date "$date_format"`] Downloading post-wipe script from $post_wipe_url\n" 2>&1 | tee -a wget.log
+		wget --no-check-certificate -O /tmp/post_wipe.sh "$post_wipe_url" -nv >> wget.log 2>&1
 		if [ $? == 0 ]
 		then
-			printf "[`date "$date_format"`] Callback script downloaded successfully\n" 2>&1 | tee -a transfer.log
-			chmod +x /tmp/nwipe_callback.sh
+			printf "[`date "$date_format"`] Post-wipe script downloaded successfully\n" 2>&1 | tee -a transfer.log
+			chmod +x /tmp/post_wipe.sh
 		else
-			printf "[`date "$date_format"`] [FAILED] Could not download callback script from $nwipe_callback_url\n" 2>&1 | tee -a transfer.log
+			printf "[`date "$date_format"`] [FAILED] Could not download post-wipe script from $post_wipe_url\n" 2>&1 | tee -a transfer.log
 			scripts_ok=0
 		fi
 	fi
@@ -497,10 +497,10 @@ do
 
 	if [ $scripts_ok == 1 ]
 	then
-		if [ "$nwipe_pre_wipe_url" != "" ]
+		if [ "$pre_wipe_url" != "" ]
 		then
 			printf "[`date "$date_format"`] Executing pre-wipe script\n" 2>&1 | tee -a transfer.log
-			/tmp/nwipe_pre_wipe.sh $nwipe_pre_wipe_options
+			/tmp/pre_wipe.sh $pre_wipe_options
 			if [ $? == 0 ]
 			then
 				printf "[`date "$date_format"`] Pre-wipe script completed successfully\n" 2>&1 | tee -a transfer.log
@@ -826,17 +826,17 @@ do
 	fi
 		printf "______________________________________________________________________________\n" 2>&1  | tee -a transfer.log
 
-	# Execute the callback script downloaded before nwipe started.
+	# Execute the post-wipe script downloaded before nwipe started.
 	#
-	if [ "$nwipe_callback_url" != "" ]
+	if [ "$post_wipe_url" != "" ]
 	then
-		printf "[`date "$date_format"`] Executing callback script\n" 2>&1 | tee -a transfer.log
-		/tmp/nwipe_callback.sh $nwipe_callback_options
+		printf "[`date "$date_format"`] Executing post-wipe script\n" 2>&1 | tee -a transfer.log
+		/tmp/post_wipe.sh $post_wipe_options
 		if [ $? == 0 ]
 		then
-			printf "[`date "$date_format"`] Callback script completed successfully\n" 2>&1 | tee -a transfer.log
+			printf "[`date "$date_format"`] Post-wipe script completed successfully\n" 2>&1 | tee -a transfer.log
 		else
-			printf "[`date "$date_format"`] Callback script exited with an error\n" 2>&1 | tee -a transfer.log
+			printf "[`date "$date_format"`] Post-wipe script exited with an error\n" 2>&1 | tee -a transfer.log
 		fi
 	fi
 


### PR DESCRIPTION
We ran in a use-case where we needed to wipe a fleet of hosts and needed to further manipulate the reports (edit reports filenames to include hostname, upload to S3 bucket, ...). 

This PR implements a way to download a callback script from any http source at runtime, and run it from within the nwipe wrapper. The same goes for the "pre-wipe" script, which can be used to check for conditions before starting the wipe for example. 

The feature is called through the kernel command line parameters "shredos_pre_wipe" and "shredos_post_wipe", where the first arg is the URL of the script (http only), and the following are passed to the script which can then parse them.

A bit of an edge case but useful nonetheless

