### PR TITLE
Fix input reading and case handling in nwipe_launcher

### DIFF
--- a/board/shredos/fsoverlay/usr/bin/nwipe_launcher
+++ b/board/shredos/fsoverlay/usr/bin/nwipe_launcher
@@ -922,7 +922,7 @@ do
                     Final_message_plus=0
                 fi
 		printf ">"
-		read -rsn1 input
+		IFS= read -rsn1 input
 		printf "\n"
 		case $input in
 			R)
@@ -947,7 +947,7 @@ do
                         fi
                         ;;
 
-			'')
+			" ")
 			printf "Restart Nwipe\n"
 			exitloop="0"
 			;;


### PR DESCRIPTION
Specifically, nwipe would restart on 'enter' not just on 'spacebar'. This fixes that so only the spacebar restarts nwipe. See issue #511 Closes #511